### PR TITLE
[IMP] pylint_odoo: Add check for invalid-commit using cr.commit directly.

### DIFF
--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -109,6 +109,14 @@ ODOO_MSGS = {
         'manifest-author-string',
         settings.DESC_DFLT
     ),
+    'E%d99' % settings.BASE_NOMODULE_ID: (
+        'Use of cr.commit() directly - More info '
+        'http://members.hellug.gr/xrg/openerp-doc/html/contribute/'
+        '15_guidelines/coding_guidelines_framework.html'
+        '#never-commit-the-transaction',
+        'invalid-commit',
+        settings.DESC_DFLT
+    ),
     'C%d01' % settings.BASE_NOMODULE_ID: (
         'Missing author required "%s" in manifest file',
         'manifest-required-author',
@@ -205,8 +213,14 @@ class NoModuleChecker(BaseChecker):
         }),
     )
 
-    @utils.check_messages('translation-field',)
+    @utils.check_messages('translation-field',
+                          'invalid-commit')
     def visit_callfunc(self, node):
+        # Check cr.commit()
+        if "cr.commit(" in node.as_string():
+            self.add_message('invalid-commit',
+                             node=node)
+
         if node.as_string().lower().startswith('fields.'):
             for argument in node.args:
                 argument_aux = argument

--- a/pylint_odoo/test/main.py
+++ b/pylint_odoo/test/main.py
@@ -8,7 +8,7 @@ from pylint.lint import Run
 from pylint_odoo import misc
 
 
-EXPECTED_ERRORS = 52
+EXPECTED_ERRORS = 54
 
 
 class MainTest(unittest.TestCase):

--- a/pylint_odoo/test_repo/broken_module/models/broken_model.py
+++ b/pylint_odoo/test_repo/broken_module/models/broken_model.py
@@ -41,9 +41,9 @@ class TestModel(models.Model):
         return variable2
 
     def my_method4(self, variable2):
-        self.env.cr2.commit()  # This cr.commit() should not be detected
+        self.env.cr2.commit()  # This should not be detected
         return variable2
 
-    def my_method4(self, variable2):
-        self.env.cr.commit2()  # This cr.commit() should not be detected too
+    def my_method5(self, variable2):
+        self.env.cr.commit2()  # This should not be detected
         return variable2

--- a/pylint_odoo/test_repo/broken_module/models/broken_model.py
+++ b/pylint_odoo/test_repo/broken_module/models/broken_model.py
@@ -35,3 +35,15 @@ class TestModel(models.Model):
 
     def my_method2(self, variable2):
         return variable2
+
+    def my_method3(self, variable2):
+        self.env.cr.commit()  # Dangerous use of commit
+        return variable2
+
+    def my_method4(self, variable2):
+        self.env.cr2.commit()  # This cr.commit() should not be detected
+        return variable2
+
+    def my_method4(self, variable2):
+        self.env.cr.commit2()  # This cr.commit() should not be detected too
+        return variable2

--- a/pylint_odoo/test_repo/broken_module/pylint_oca_broken.py
+++ b/pylint_odoo/test_repo/broken_module/pylint_oca_broken.py
@@ -56,6 +56,10 @@ class ApiOne(object):
         # Missing super()
         pass
 
+    def my_method3(self):
+        self.env.cr.commit()  # Dangerous use of commit
+        pass
+
 
 class One(object):
     @one


### PR DESCRIPTION
# [VX#4932] (https://www.vauxoo.com/web#id=4932&view_type=form&model=project.task&menu_id=136&action=138)

- [x] Add new check for `invalid commit`.

![pylint_odoo_cr_commit](https://cloud.githubusercontent.com/assets/11741384/13720395/020c370a-e7cd-11e5-9502-596a464dbe2d.png)

