### PR TITLE
[FIX] pylint_odoo: The check duplicate-xml-fields skip if the field is inside the search tag

### DIFF
--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -569,7 +569,8 @@ class ModuleChecker(misc.WrapperModuleChecker):
         all_fields = {}
         for field in fields:
             field_xml = field.attrib.get('name')
-            if not field_xml:
+            if (not field_xml or (field.getparent()
+                                  and field.getparent().tag == 'search')):
                 continue
             all_fields.setdefault(
                 (field_xml, field.getparent()), []).append(field)

--- a/pylint_odoo/test_repo/broken_module/model_view_odoo2.xml
+++ b/pylint_odoo/test_repo/broken_module/model_view_odoo2.xml
@@ -32,6 +32,17 @@
             </field>
         </record>
 
+        <!-- duplicate record field "name" inside the search -->
+        <record model="ir.ui.view" id="view_ir_config_search">
+            <field name="model">ir.config_parameter</field>
+            <field name="arch" type="xml">
+                <search string="System Properties">
+                    <field name="key_config" context="{'one': 'data'}"/>
+                    <field name="key_config" context="{'two': 'data'}"/>
+                </search>
+            </field>
+        </record>
+
          <!-- inherit view without duplicated is not checked -->
         <record id="view_model_form4" model="ir.ui.view">
             <field name="name">view.model.form</field>


### PR DESCRIPTION
The check `duplicate-xml-fields` skip the comprobation if the field is inside the `search` tab

For example 

```xml
<record model="ir.ui.view" id="view_ir_config_search">
    <field name="model">ir.config_parameter</field>
    <field name="arch" type="xml">
        <search string="System Properties">
            <field name="key_config" context="{'one': 'data'}"/>
            <field name="key_config" context="{'two': 'data'}"/>
        </search>
    </field>
</record>
```

Fix https://github.com/OCA/pylint-odoo/issues/169
