### PR TITLE
[FIX] pylint_odoo: Fix the method wrapper_visit_module

### DIFF
--- a/pylint_odoo/misc.py
+++ b/pylint_odoo/misc.py
@@ -173,7 +173,7 @@ class PylintOdooChecker(BaseChecker):
                         node_lineno_original = node.lineno
                         msg_args_extra = self.set_extra_file(node, msg_args,
                                                              msg_code)
-                        self.add_message(msg_code, line=node.lineno, node=node,
+                        self.add_message(name_key, line=node.lineno, node=node,
                                          args=msg_args_extra)
                         node.file = node_file_original
                         node.lineno = node_lineno_original


### PR DESCRIPTION
When the xml check is process and found a message the method `add_message` is called with the name of the check not with the number of this check

