### PR TITLE
[ADD] pylint-odoo: ecma version set to 6 in the parserOptions for ESlint

### DIFF
--- a/pylint_odoo/examples/.jslintrc
+++ b/pylint_odoo/examples/.jslintrc
@@ -267,5 +267,7 @@
     "yield-star-spacing": "off",
     "yoda": "error"
   },
-  "parserOptions": {}
+  "parserOptions": {
+    "ecmaVersion": 6
+  }
 }


### PR DESCRIPTION
this changes may allow to code EcmaScript2015 Javascript syntax