### PR TITLE
[FIX] translation-positional-used: Limit only for >=14.0

### DIFF
--- a/pylint_odoo/checkers/no_modules.py
+++ b/pylint_odoo/checkers/no_modules.py
@@ -334,6 +334,13 @@ class NoModuleChecker(misc.PylintOdooChecker):
 
     name = settings.CFG_SECTION
     msgs = ODOO_MSGS
+
+    odoo_check_versions = {
+        'translation-positional-used': {
+            'min_odoo_version': '14.0',
+        },
+    }
+
     options = (
         ('manifest_required_authors', {
             'type': 'csv',


### PR DESCRIPTION
<=13.0 does not have positional arguments:
 - https://github.com/odoo/odoo/blob/a03aa23461498bba67/odoo/tools/translate.py#L447

>=14.0 has positional arguments:
 - https://github.com/odoo/odoo/blob/6a6e5f92789e1c/odoo/tools/translate.py#L446

So, we only are limiting this check for odoo >=14.0 since past version is not already valid