### PR TITLE
[FIX] missing-import-error: add xlrd to whitelist

### DIFF
--- a/pylint_odoo/checkers/modules_odoo.py
+++ b/pylint_odoo/checkers/modules_odoo.py
@@ -204,7 +204,7 @@ DFLT_IMPORT_NAME_WHITELIST = [
     'pydot', 'pyparsing', 'pytz', 'qrcode', 'reportlab',
     'requests', 'serial', 'simplejson', 'six', 'suds',
     'unittest2', 'urllib3', 'usb', 'vatnumber', 'vobject', 'werkzeug',
-    'wsgiref', 'xlsxwriter', 'xlwt', 'yaml',
+    'wsgiref', 'xlrd', 'xlsxwriter', 'xlwt', 'yaml',
     # OpenUpgrade migration
     'openupgradelib'
 ]


### PR DESCRIPTION
The `xlrd` package is in Odoo's requirements since v10 [1].

[1] https://github.com/odoo/odoo/commit/0ac303d12ff0